### PR TITLE
Fix: include text_content key when merging clearnet side-source pages

### DIFF
--- a/voidaccess_cli/commands/investigate.py
+++ b/voidaccess_cli/commands/investigate.py
@@ -310,7 +310,7 @@ async def _run_investigation(
     for extra in (paste_pages, github_pages, gitlab_pages, rss_pages):
         for page in extra:
             url = page.get("url") or page.get("link")
-            text = page.get("text") or page.get("content") or page.get("cleaned_text") or ""
+            text = page.get("text") or page.get("content") or page.get("cleaned_text") or page.get("text_content") or ""
             if not url or not text:
                 continue
             scraped_pages.append({"url": url, "text": text, "source": page.get("source", "clearnet")})


### PR DESCRIPTION
## Problem

The clearnet side-source merge in `voidaccess_cli/commands/investigate.py` reads each page body from `text` / `content` / `cleaned_text`, but the `sources/*` scrapers (GitHub, RSS, paste, GitLab) return the body under the key `text_content`. Every clearnet page therefore fails the `if not url or not text: continue` check and is dropped, so `investigate` returns **0 pages / 0 entities — silently** whenever it relies on clearnet sources (e.g. `--no-tor`, or when the Tor search returns no links). `sources_used` still reports non-zero counts, which makes the empty result confusing to diagnose.

## Fix

Add `text_content` to the fallback chain. Minimal and non-breaking — the scrapers and their other consumers (which standardize on `text_content`) are untouched.

```python
text = page.get("text") or page.get("content") or page.get("cleaned_text") or page.get("text_content") or ""
```

## Before / after

`voidaccess investigate "LockBit" --no-tor`:
- before: 0 pages, 0 entities, empty summary
- after: 24 pages, 113 entities, graph + LLM summary
